### PR TITLE
added a css styling of position: realitve

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -46,6 +46,10 @@ footer {
   padding-top: 2px;
 }
 
+#park-search{
+  position: relative;
+}
+
 /* sg: for map 1.31.2021 */
 #map-container {
   width: 80%;


### PR DESCRIPTION
this fixed the issue of the state search being a level higher when the page was scrolled. It now stays behind the navbar as page is scrolled. 